### PR TITLE
Update README.md - fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Blackjack hand, tell it what card the dealer has facing up, and it will tell you
 what your optimal next move is based on
 [basic strategy](http://www.blackjackcalculation.com/blackjack-great-basic-strat.png).
 
-[![Click here to try it!](blackjack.gif)](https://roboflow-ai.github.io/blackjack-basic-strategy/)
+[![Click here to try it!](blackjack.gif)](https://roboflow.github.io/blackjack-basic-strategy/)
 
 ## [🤳 Try it on your phone or in your web browser on GitHub Pages here.](https://roboflow-ai.github.io/blackjack-basic-strategy/)
 
@@ -22,7 +22,7 @@ This app was live coded on YouTube; [watch the recording](https://www.youtube.co
 
 ### Resources
 
-* [Try It](https://roboflow-ai.github.io/blackjack-basic-strategy/) - this project is deployed on GitHub Pages. You can try it on your phone or computer's webcam. Just point your camera at a Blackjack hand, select the dealer's face-up card, and it will tell you what to do.
+* [Try It](https://roboflow.github.io/blackjack-basic-strategy/) - this project is deployed on GitHub Pages. You can try it on your phone or computer's webcam. Just point your camera at a Blackjack hand, select the dealer's face-up card, and it will tell you what to do.
 * [Roboflow Universe](https://universe.roboflow.com) - share computer vision datasets and pre-trained models.
 * [Playing Cards Pre-Trained Model](https://universe.roboflow.com/augmented-startups/playing-cards-ow27d) - shared on Roboflow Universe by [Augmented Startups](https://www.augmentedstartups.com/).
 * [Roboflow YouTube](https://www.youtube.com/channel/UCUlRrGpNRT5jbiV8h5Q_4Fg?sub_confirmation=1) - where you can follow along with the live-coding session of this app being built and find other computer vision content.


### PR DESCRIPTION
Fix broken GitHub pages links from move to roboflow, from roboflow-ai
# Description

When we moved to roboflow for our GitHub org name, it changed the links to our GitHub pages. This remedies the issue for blackjack basic strategy

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested the link in my browser

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:

No docs changes needed. Updated the link in the ReadMe.md file